### PR TITLE
Remove debug timer warning

### DIFF
--- a/stack/pico_stack.c
+++ b/stack/pico_stack.c
@@ -831,9 +831,6 @@ pico_timer_ref_add(pico_time expire, struct pico_timer *t, uint32_t id, uint32_t
         pico_err = PICO_ERR_ENOMEM;
         return 0;
     }
-    if (Timers->n > PICO_MAX_TIMERS) {
-        dbg("Warning: I have %d timers\n", (int)Timers->n);
-    }
 
     return tref.id;
 }


### PR DESCRIPTION
PICO_MAX_TIMERS seems to be an arbitrary limit that is frequently met. This causes a lot of debug output which can be confusing for students when there seems to be no real consequence of exceeding this limit